### PR TITLE
fix: cErr for CountourGenerate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+examples/*/go.sum
 examples/tiff/tiff
 examples/translate/translate
 examples/warp/warp

--- a/algorithms.go
+++ b/algorithms.go
@@ -309,7 +309,7 @@ func (src RasterBand) ContourGenerate(
 		fixedLevels_p = (*C.double)(unsafe.Pointer(&fixedLevels[0]))
 	}
 
-	return CPLErr(C.GDALContourGenerate(
+	cErr := C.GDALContourGenerate(
 		src.cval,
 		C.double(interval),
 		C.double(base),
@@ -322,7 +322,9 @@ func (src RasterBand) ContourGenerate(
 		C.int(elevationFieldIndex),
 		C.goGDALProgressFuncProxyB(),
 		unsafe.Pointer(arg),
-	)).Err()
+	)
+
+	return CPLErrContainer{ErrVal: cErr}.Err()
 }
 
 /* --------------------------------------------- */


### PR DESCRIPTION
In this pull request, I try to fix the error of `ContourGenerate` according to the following PR:
- https://github.com/lukeroth/gdal/pull/102

And as an additional, I had added number of go.sum for every example to keep them clean.